### PR TITLE
refactor: change interface to type and remove React.FC ref

### DIFF
--- a/src/components/Button.tsx
+++ b/src/components/Button.tsx
@@ -2,19 +2,13 @@ import clsx from "clsx";
 import { twMerge } from "tailwind-merge";
 import React from "react";
 
-interface Props {
+type ButtonProps = {
   children: React.ReactNode;
   className?: string;
   href?: string;
-  [otherProps: string]: any;
-}
+};
 
-const Button: React.FC<Props> = ({
-  children,
-  className,
-  href,
-  ...otherProps
-}) => {
+const Button = ({ children, className, href, ...otherProps }: ButtonProps) => {
   const Element = href ? "a" : "button";
 
   return (

--- a/src/components/Card.tsx
+++ b/src/components/Card.tsx
@@ -1,12 +1,10 @@
-import React from "react";
-
-interface Props {
+type CardProps = {
   first_name: string;
   last_name: string;
   duration: string;
-}
+};
 
-const Card: React.FC<Props> = ({ first_name, last_name, duration }) => (
+const Card = ({ first_name, last_name, duration }: CardProps) => (
   <li className="odd:bg-purple even:bg-navy text-white rounded-lg p-4 w-72 h-44 flex items-end shrink-0">
     <div>
       <p className="font-semibold">{`${first_name} ${last_name}`}</p>

--- a/src/components/Container.tsx
+++ b/src/components/Container.tsx
@@ -1,12 +1,12 @@
 import clsx from "clsx";
 import React from "react";
 
-interface Props {
+type ContainerProps = {
   children: React.ReactNode;
-  className: string;
+  className?: string;
 }
 
-const Container: React.FC<Props> = ({ children, className }) => (
+const Container = ({ children, className }: ContainerProps) => (
   <div className={clsx("max-w-md mx-auto py-20 px-8", className)}>
     {children}
   </div>

--- a/src/components/Heading.tsx
+++ b/src/components/Heading.tsx
@@ -1,10 +1,8 @@
-import React from "react";
+type HeadingProps = {
+  children: JSX.Element | string;
+};
 
-interface Props {
-  children: string;
-}
-
-const Heading: React.FC<Props> = ({ children }) => (
+const Heading = ({ children }: HeadingProps) => (
   <h1 className="text-2xl font-bold">{children}</h1>
 );
 

--- a/src/components/Input.tsx
+++ b/src/components/Input.tsx
@@ -1,11 +1,9 @@
-import React from "react";
-
-interface Props {
+type InputProps = {
   label: string;
   name: string;
-}
+};
 
-const Input: React.FC<Props> = ({ label, name, ...otherProps }) => (
+const Input = ({ label, name, ...otherProps }: InputProps) => (
   <div>
     <label htmlFor={name} className="text-sm text-gray font-semibold">
       {label}

--- a/src/components/Layout.tsx
+++ b/src/components/Layout.tsx
@@ -1,9 +1,7 @@
-import React from "react";
-
-interface Props {
+type LayoutProps = {
   children: JSX.Element;
-}
+};
 
-const Layout: React.FC<Props> = ({ children }) => <div>{children}</div>;
+const Layout = ({ children }: LayoutProps) => <div>{children}</div>;
 
 export default Layout;

--- a/src/components/Subheading.tsx
+++ b/src/components/Subheading.tsx
@@ -1,12 +1,11 @@
 import clsx from "clsx";
-import React from "react";
 
-interface Props {
-  children: JSX.Element|string;
-  className: string;
-}
+type SubheadingProps = {
+  children: JSX.Element | string;
+  className?: string;
+};
 
-const Subheading: React.FC<Props> = ({ children, className }) => (
+const Subheading = ({ children, className }: SubheadingProps) => (
   <h1 className={clsx(className, "text-gray font-semibold")}>{children}</h1>
 );
 

--- a/src/context/LoginContext.tsx
+++ b/src/context/LoginContext.tsx
@@ -1,0 +1,16 @@
+import { createContext, useState } from "react";
+
+interface CurrentUser {
+  first_name: string;
+  last_name: string;
+  id: number;
+}
+
+const CurrentUserContext = createContext<CurrentUser | null>(null);
+
+const CurrentUserProvider = ({ children }) => {
+  const [user, setUser] = useState<CurrentUser>(null);
+  return <CurrentUserContext.Provider>{children}</CurrentUserContext.Provider>;
+};
+
+export { CurrentUserProvider, CurrentUserContext };

--- a/src/views/Dashboard.tsx
+++ b/src/views/Dashboard.tsx
@@ -1,19 +1,19 @@
-import React, { useEffect, useState } from "react";
+import { useEffect, useState } from "react";
 
 import Container from "../components/Container.jsx";
 import Heading from "../components/Heading.jsx";
 import Subheading from "../components/Subheading.jsx";
 import Card from "../components/Card.jsx";
 
-interface Props {
+type DashboardProps = {
   bookings: Array<object>;
-}
+};
 
-const Upcoming: React.FC<Props> = ({ bookings }) => (
+const Upcoming = ({ bookings }: DashboardProps) => (
   <div>
     <Subheading className="mb-4">Upcoming</Subheading>
     <ul className="flex gap-4 overflow-x-hidden">
-      {bookings.map((booking: object) => (
+      {bookings.map((booking) => (
         <Card key={booking.id} {...booking} />
       ))}
     </ul>

--- a/src/views/SignUp.tsx
+++ b/src/views/SignUp.tsx
@@ -25,7 +25,7 @@ const handleSubmit = (e: React.FormEvent) => {
   }
 };
 
-const SignUpForm: React.FC = () => (
+const SignUpForm = () => (
   <form onSubmit={handleSubmit}>
     <div className="space-y-4">
       <Input name="fname" type="text" label="First name" required />
@@ -46,7 +46,7 @@ const SignUpForm: React.FC = () => (
   </form>
 );
 
-const SignUp: React.FC = () => (
+const SignUp = () => (
   <Container className="space-y-8">
     <Heading>Sign up</Heading>
     <SignUpForm />


### PR DESCRIPTION
As of `TypeScript 5.1` React.FC is discouraged so removed every reference to that, also replaced interface to be a type